### PR TITLE
chore: add correct git commit conventional types

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,19 @@ npm run dev
 ```sh
 npm run build
 ```
+
+### Conventional Commit Types
+
+| **Type**       | **Purpose** |
+|----------------|-------------|
+| **`feat`**     | Add a new feature (functions, logic) |
+| **`fix`**      | Fix a bug (incorrect output, logic errors) |
+| **`refactor`** | Improve code without changing behavior |
+| **`perf`**     | Optimize performance (faster loops, better memory usage) |
+| **`style`**    | Formatting changes (indentation, comments) |
+| **`test`**     | Add or update test cases |
+| **`build`**    | Modify Makefile or compilation setup |
+| **`docs`**     | Update README, specs, or comments |
+| **`chore`**    | Non-code maintenance (renaming files, updating `.gitignore`) |
+
+> [See conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)


### PR DESCRIPTION
# Why your commit conventions dont make sense

> These are the most common commit conventions you will see in the industry and the open source world. The convention itself coming from the Angular Commit Guidelines have stood the test of time. Tools for handling git, version control, and merge conflicts also default to these conventions. 
---
- If you want *nit:* you have *style:*
- If you want *bin:* you have *build:*
- If you want *minor:* the question now is why do you want minors in your commits just use *refactor:*

[Your Conventions](https://gist.github.com/johnstew/941676d525271359a4b2d7f1bf2cb421)

[Standard Conventions](https://www.conventionalcommits.org/en/v1.0.0/) 